### PR TITLE
fix: compatible with Go 1.16

### DIFF
--- a/blackmagic.go
+++ b/blackmagic.go
@@ -25,7 +25,7 @@ import (
 func AssignOptionalField(dst, src interface{}) error {
 	dstRV := reflect.ValueOf(dst)
 	srcRV := reflect.ValueOf(src)
-	if dstRV.Kind() != reflect.Pointer || dstRV.Elem().Kind() != reflect.Pointer {
+	if dstRV.Kind() != reflect.Ptr || dstRV.Elem().Kind() != reflect.Ptr {
 		return fmt.Errorf(`dst must be a pointer to a field that is turn a pointer of src (%T)`, src)
 	}
 


### PR DESCRIPTION
go.mod file sets go1.16, but the code uses reflect.Pointer, which is only available in go1.18+.


```powershell
PS D:\go\pkg\mod\github.com\lestrrat-go\blackmagic@v1.0.2> go version
go version go1.16.15 windows/amd64
PS D:\go\pkg\mod\github.com\lestrrat-go\blackmagic@v1.0.2> go test .
# github.com/lestrrat-go/blackmagic
.\blackmagic.go:28:21: undefined: reflect.Pointer
FAIL    github.com/lestrrat-go/blackmagic [build failed]
FAIL
```